### PR TITLE
Fix file saving for TCCON only

### DIFF
--- a/r/src/before_footprint_xstilt.r
+++ b/r/src/before_footprint_xstilt.r
@@ -70,6 +70,12 @@ before_footprint_xstilt = function() {
         # ---------------------------------------------------------------------
         cat('based on TCCON AK and integration operators\n')
 
+        output_combined <- NULL
+        output_combined$file = output$file
+        output_combined$receptor = output$receptor
+        output_combined$qt_prof = output$qt_prof
+        output_combined$params = output$params
+
         # if there are more than one non-CO2 species, calc footprint first
         non_co2_species = obs_species[ obs_species != 'CO2' ]
 
@@ -79,6 +85,9 @@ before_footprint_xstilt = function() {
                 tmp_output = wgt.trajec.foot.tccon(output = output, 
                                                    tccon.fn = obs_fn, 
                                                    tccon.species = ss)
+                
+                output_combined[[paste('particle', tolower(ss), sep='_')]] = tmp_output$particle
+                output_combined[[paste('combine.prof', tolower(ss), sep='_')]] = tmp_output$combine.prof
                 
                 # then generated foots for non-CO2 species
                 tmp_fn = file.path(rundir, paste0(simulation_id, '_', ss, 
@@ -97,6 +106,10 @@ before_footprint_xstilt = function() {
         # default footprint weighting is to use CO2 weighting profiles 
         output = wgt.trajec.foot.tccon(output = output, tccon.fn = obs_fn, 
                                        tccon.species = 'CO2')
+        
+        output_combined[['particle_co2']] = output$particle
+        output_combined[['combine.prof_co2']] = output$combine.prof
+        saveRDS(output_combined, output$file)
     }
     
     cat('before_footprint_xstilt(): DONE with footprint weighting...\n')

--- a/r/src/recp_trajec_foot/wgt.trajec.foot.tccon.r
+++ b/r/src/recp_trajec_foot/wgt.trajec.foot.tccon.r
@@ -35,10 +35,15 @@ wgt.trajec.foot.tccon = function(output, tccon.fn = NA,
 	# use retrieved surface pressure and height for pressure weighting
 	# use retrieved Ak for AK weighting
     #source('r/dependencies.r')
-	xstilt.prof = get.wgt.tccon.func(output, tccon.fn, tccon.species) %>% 
-			      dplyr::select(-c('pres')) %>% filter(stiltTF == TRUE)
-	colnames(xstilt.prof)[ colnames(xstilt.prof) == 'ap_gas_wet'] = 
+
+	combine.prof = get.wgt.tccon.func(output, tccon.fn, tccon.species)
+	colnames(combine.prof)[ colnames(combine.prof) == 'ap_gas_wet'] = 
 		paste0('ap_', tolower(tccon.species), '_wet')
+
+	output$combine.prof = combine.prof
+	
+	xstilt.prof = combine.prof %>% filter(stiltTF == TRUE) %>% 
+					dplyr::select(-c('pres'))
 
 	### STARTing weighting trajec based on profile
 	# weighting foot by multipling AK and PW profiles from 'xstiltprof'
@@ -72,7 +77,7 @@ wgt.trajec.foot.tccon = function(output, tccon.fn = NA,
 
 
 	# return both weighting profiles and weighted trajec
-	saveRDS(output, output$file) 	# overwrite the "X_traj.rds" file
+	#saveRDS(output, output$file) 	# overwrite the "X_traj.rds" file
 	return(output)
 
 }  # end of subroutine


### PR DESCRIPTION
There were two issues with the _traj.rds file being saved when running footprints for multiple species with TCCON. 

1. The rds file was missing the full profile information to combine the TCCON column. It was only saving info for particles below release height. To fix this I have added a "combine.prof" variable to the "output" variable in wgt.trajec.foot.tccon.r.

2. The rds file was being overwritten by "saveRDS" in wgt.trajec.foot.tccon.r for CO2 at the end of the non-co2 species loop in before_footprint_xstilt.r. To fix this I have moved the "saveRDS" line out of wgt.trajec.foot.tccon.r and up to before_footprint_xstilt.r. For every relevant species, a particle_species and combine.prof_species variable will be added to "output_combined" and saved at the end. This allows "output" to still represent co2 at the end of before_footprint_xstilt.r.

I am submitting this PR to bring these issues to light and to show the changes I have needed to make to use X-STILT in my own work. I would imagine there are better ways of fixing the problems above. I would be happy to test alternative fixes. Thanks so much.