### PR TITLE
Changes to TCCON pressure grid and .rds file

### DIFF
--- a/r/src/before_footprint_xstilt.r
+++ b/r/src/before_footprint_xstilt.r
@@ -76,7 +76,7 @@ before_footprint_xstilt = function() {
         if ( length(non_co2_species) > 0 ) {    
             for ( ss in non_co2_species) {
                 cat('\n\nbefore_footprint_xstilt(): working on', ss, '\n')
-                tmp_output = wgt.trajec.foot.tccon(output = output, 
+                output = wgt.trajec.foot.tccon(output = output, 
                                                    tccon.fn = obs_fn, 
                                                    tccon.species = ss)
                 
@@ -85,7 +85,7 @@ before_footprint_xstilt = function() {
                                                   '_foot.nc'))
 
                 # use weighted output for footprint
-                calc_footprint(p = tmp_output$particle, output = tmp_fn, 
+                calc_footprint(p = output$particle, output = tmp_fn, 
                                r_run_time = r_run_time, 
                                smooth_factor = smooth_factor,
                                time_integrate = time_integrate,
@@ -93,7 +93,7 @@ before_footprint_xstilt = function() {
                                ymn = ymn, ymx = ymx, yres = yres)
             }   # end for
         } 
-        
+        cat('\n\nbefore_footprint_xstilt(): working on CO2\n')
         # default footprint weighting is to use CO2 weighting profiles 
         output = wgt.trajec.foot.tccon(output = output, tccon.fn = obs_fn, 
                                        tccon.species = 'CO2')

--- a/r/src/before_footprint_xstilt.r
+++ b/r/src/before_footprint_xstilt.r
@@ -91,6 +91,10 @@ before_footprint_xstilt = function() {
                                time_integrate = time_integrate,
                                xmn = xmn, xmx = xmx, xres = xres,
                                ymn = ymn, ymx = ymx, yres = yres)
+
+                # Symlink non-co2 footprints to out/footprints
+                link_files(tmp_fn, file.path(output_wd, 'footprints'))
+
             }   # end for
         } 
         cat('\n\nbefore_footprint_xstilt(): working on CO2\n')

--- a/r/src/column_obs/tccon_functions/get.tccon.info.r
+++ b/r/src/column_obs/tccon_functions/get.tccon.info.r
@@ -37,6 +37,9 @@ get.tccon.info = function(tccon.fn, receptor,
     ap_gas_wet = ncvar_get(dat, paste0('prior_', tolower(tccon.species)))[, time_indx]
     ap_h2o_wet = ncvar_get(dat, 'prior_h2o')[, time_indx]
 
+    # prior pressure in hPa, for int_op, ap_gas_wet, ap_h2o_wet
+    prior_pres = ncvar_get(dat, 'prior_pressure')[, time_indx] * 1013.25
+
     # now for AKs [levels, timestamps]
     # Median pressure for the column averaging kernels vertical grid, hPa
     ak_pres = ncvar_get(dat, 'ak_pressure')
@@ -46,7 +49,7 @@ get.tccon.info = function(tccon.fn, receptor,
     
     # store 2D array of int operator and AKs --------------------
     wgt_df = data.frame(ak_pres, ak_norm, ap_gas_wet = ap_gas_wet, 
-                        ap_h2o_wet = ap_h2o_wet, int_op)
+                        ap_h2o_wet = ap_h2o_wet, int_op, prior_pres)
     info = list(species = tccon.species, zasl_m = zasl_m, psfc_hpa = pres_hpa, 
                 xh2o_ppm = xh2o_ppm, x_gas = x_gas, xap_gas = xap_gas, 
                 wgt = wgt_df)


### PR DESCRIPTION
Hi Dien,

These are the changes I made based on our previous discussion #13. Now ak.norm_gas, ak.pwf_gas, and ap_gas_wet get added as columns to output$combine.prof for each gas. Similarly foot_gas gets added as a column to output$particle for each gas.

I also changed the TCCON pressure grid to be based on prior_pressure instead of ak_pressure. And I added symbolic linking for the non-co2 footprint files. If there are better ways to make any of these changes, please totally ignore this PR. Just thought I'd try to lend a hand.

I have been testing it with these changes and your recent updates and everything is mostly ok. I have run into a very strange bug where trajectories at 22:00 UTC are failing in get.met.vars.r. It fails to run the 1-hour back-trajectory used to get the wind/temp, pressure, etc. This is happening across multiple days and always at 22:00, but not at 21:00 or 23:00. I am using gfs0p25 and was not having this issue before your recent changes. Hope we can track that down, thanks.

Thanks,
Jon-Paul